### PR TITLE
feat: Add GAN implementation with JAX

### DIFF
--- a/GAN_with_JAX.ipynb
+++ b/GAN_with_JAX.ipynb
@@ -1,0 +1,346 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2025-03-01T20:02:24.466154Z",
+     "start_time": "2025-03-01T20:02:18.676036Z"
+    }
+   },
+   "source": [
+    "import jax.tools.colab_tpu\n",
+    "try:\n",
+    "    jax.tools.colab_tpu.setup_tpu()\n",
+    "except:\n",
+    "    pass"
+   ],
+   "outputs": [],
+   "execution_count": 1
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-01T21:57:39.729614Z",
+     "start_time": "2025-03-01T21:57:39.725725Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "from jax.nn.initializers import normal as normal_init\n",
+    "from flax.training import train_state\n",
+    "from flax import linen as nn\n",
+    "import optax"
+   ],
+   "id": "80ee28f583eab935",
+   "outputs": [],
+   "execution_count": 45
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-01T20:17:48.158074Z",
+     "start_time": "2025-03-01T20:17:48.155639Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "import tensorflow_datasets as tfds\n",
+    "import matplotlib.pyplot as plt"
+   ],
+   "id": "ec7ab6728851b3c1",
+   "outputs": [],
+   "execution_count": 29
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Load the Fashion MNIST dataset",
+   "id": "e00b3a5759190eba"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-01T20:17:54.120832Z",
+     "start_time": "2025-03-01T20:17:53.341787Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Load the Fashion MNIST dataset\n",
+    "def load_fashion_mnist():\n",
+    "    ds_builder = tfds.builder('fashion_mnist')\n",
+    "    ds_builder.download_and_prepare()\n",
+    "    train_ds = tfds.as_numpy(ds_builder.as_dataset(split='train', batch_size=-1))\n",
+    "    test_ds = tfds.as_numpy(ds_builder.as_dataset(split='test', batch_size=-1))\n",
+    "\n",
+    "    train_images, train_labels = train_ds['image'], train_ds['label']\n",
+    "    test_images, test_labels = test_ds['image'], test_ds['label']\n",
+    "\n",
+    "\n",
+    "    return (train_images, train_labels), (test_images, test_labels)\n",
+    "\n",
+    "(train_images, train_labels), (test_images, test_labels) = load_fashion_mnist()\n",
+    "print(f\"Train images shape: {train_images.shape}, Train labels shape: {train_labels.shape}\")\n",
+    "print(f\"Test images shape: {test_images.shape}, Test labels shape: {test_labels.shape}\")"
+   ],
+   "id": "81914495db53fe15",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train images shape: (60000, 28, 28, 1), Train labels shape: (60000,)\n",
+      "Test images shape: (10000, 28, 28, 1), Test labels shape: (10000,)\n"
+     ]
+    }
+   ],
+   "execution_count": 30
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-01T20:17:58.912454Z",
+     "start_time": "2025-03-01T20:17:58.840951Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "# Select only the images with labels 5, 7, and 9\n",
+    "selected_labels = jnp.array([5, 7, 9])\n",
+    "selected_images = train_images[jnp.isin(train_labels, selected_labels)]\n",
+    "\n",
+    "# Display the first 10 images with labels 5, 7, and 9\n",
+    "fig, axes = plt.subplots(1, 10, figsize=(20, 2))\n",
+    "for i, ax in enumerate(axes):\n",
+    "    ax.imshow(selected_images[i], cmap='gray')\n",
+    "    ax.axis('off')\n",
+    "plt.show()"
+   ],
+   "id": "5cef2f20ab76a07",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 2000x200 with 10 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABiEAAACXCAYAAABzwvhEAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAMXRJREFUeJzt3XeUVdX5xvFrVIYiVXoHpYuAiBBAQBRQFLumCCpWrBFj7xVdWIjGEhPi0thi17gU1LjsCAIiVVSKdGQU6QKi/Nb89ct53+fO3lznzB2Y7+e/8659z5x7zz77tDX72W379u3bMwAAAAAAAAAAACXsNyW9QgAAAAAAAAAAgCK8hAAAAAAAAAAAAKngJQQAAAAAAAAAAEgFLyEAAAAAAAAAAEAqeAkBAAAAAAAAAABSwUsIAAAAAAAAAACQCl5CAAAAAAAAAACAVPASAgAAAAAAAAAApIKXEAAAAAAAAAAAIBV7xDbcbbfd0tkC7JS2b99eKn9nZ+l3ajtz/Y0qVKgQtf7q1asnlgsKClybmjVrulqjRo1crXLlyonlqlWrujYVK1Z0tSpVqiSWf/nlF9fmrbfecrU6depkQj766CNX++mnnzJp21n6HEoHYx3ygX6HXbXf0efwvxjrkA+MdShtjHXIB/odymK/4z8hAAAAAAAAAABAKngJAQAAAAAAAAAAUsFLCAAAAAAAAAAAkN9MCAA7Zvfdd3e1n3/+2dVGjRqVWO7SpYtrs2XLFldr165dMLPhN7/x7xk3bdoUrG3dutW12WMPP1xs2LAhsbx27VrX5uyzz3a1GTNmuNpLL72UWN62bZtrAwAAAAAAAGDnwn9CAAAAAAAAAACAVPASAgAAAAAAAAAApIKXEAAAAAAAAAAAIBVkQgAlYPv27VF5DCoT4ssvv0wst2/f3rXZvHmzq82ZMyexXFhYGPX3KlSoELWtMZkQdv21atVybe677z5Xmz9/vqu98847wW0AAAAAAPx66h7wl19+yZRFTZo0Cd6LHn/88a7NAw88kOp2AQDi8Z8QAAAAAAAAAAAgFbyEAAAAAAAAAAAAqeAlBAAAAAAAAAAASAUvIQAAAAAAAAAAQCoIpgZKMaxascHUlSpVcm2qVKkSrDVt2jRqG3bbbbdg6PRPP/0UFVK2bt26YOi18t1337la5cqVE8sbN26MWhcAAAAAoGypVauWq3Xs2DEYjm3vTbOFTtv74Z49e7o2b7/9tqu1b98++Pfee+89VyssLHQ1ALs++5xr69atrk3v3r1drWvXronlhx56yLVRz952ZfwnBAAAAAAAAAAASAUvIQAAAAAAAAAAQCp4CQEAAAAAAAAAAFLBSwgAAAAAAAAAAJAKgqmBlKgAaMWGO6tgLBVWs2XLlmAbFUwdG1Zt7b777q5mt7WgoMC12bRpUyZG/fr1E8vz58+P+hwAAACA4q/t1T0Ayrdffvklqp0Kj4757KBBg1xtn332SSy3bt06qv++//77rrb//vsnlj///HPXZsSIEa62bNmyxPL333/v2tx7772uNmzYsEwuvxWAnYd67qWCqK1TTjnF1fr165dYHjx4sGvzySefuNr48eNdzT5r27x5s2ujngnasdo+f8w2btnnjeq3WbRoUWZHMUICAAAAAAAAAIBU8BICAAAAAAAAAACkgpcQAAAAAAAAAAAgFbyEAAAAAAAAAAAAqSCYupyHfO21116utmHDhpwClpGbtWvXBgNmVDhOTBiYarPnnnu6mt3H27ZtiwqmsQE2DRs2dG2++OILV6tWrZqrVahQIbFMMDUAAACw40ry/rRu3bqudvrpp7taz549E8uFhYWuzYwZM1ytevXqieXKlStHhW3+85//dLXFixe7GkovwDr0XKHIbbfdlilrbN8tsmbNmmBfVffyuf5WAEqfCmSOef45cOBAV+vVq5erLVu2LLFcqVKlqPPplVde6WrqGV2uz/9iLF26NPjbXHvttTu8Xv4TAgAAAAAAAAAApIKXEAAAAAAAAAAAIBW8hAAAAAAAAAAAAKkgEyKF/Ifhw4e7Wp8+faLmH7O1PfbYI2pOzEWLFiWWV61a5do0btzY1UaNGuVqMduJsNj5IO08kg0aNHBtVq9eHZUTket22Xni1LpVP7B90eY6FFmxYoWr9e/fP2reTQAAAAD5u7d97rnnonIFmzVrFrwvaN68uavVqFEjsVyrVq2oPLkmTZq42hlnnOFqyJ8BAwa42vjx44PPNtJ2yCGHJJZr167t2qxbt87VOnTo4GoTJkxILPPsBNh5qHNgTPZCv379XE1lmtpz3tatW12b77//3tU2bdrkavacWlBQEJX/YMcy1Wb9+vWuNnv2bFezz6dfeumlzI5ihAQAAAAAAAAAAKngJQQAAAAAAAAAAEgFLyEAAAAAAAAAAEAqeAkBAAAAAAAAAABSQTB1CYR3jR49OrHcq1cv16Zq1apR67JBRio0pFKlSsHPxQYS33rrrTn9Dii5YOoNGzYEQ2Fi9q8K0FFhNSp02n42NiDMbpcN2c7Wf5544glXU4HcAAAAAPKncuXKUYGVtp26Z507d66rtW3bNngPtXr16pzvtZCdetaQa1C0ChTv27dvia0/VzYwXfU5pXv37q522WWXldh2Acg/9Uw2xsEHH+xqP/74YzBgerU4l6lnxVWqVCmx57I2TFqtRz1vbNmyZfD3ignxdn9rhz8BAAAAAAAAAAAQgZcQAAAAAAAAAAAgFbyEAAAAAAAAAAAAqeAlBAAAAAAAAAAASAXB1MUEdMSGXXXr1q3YoOFsYcOq9v333we3QQUL16lTJ7Fco0aNqMCTn3/+2dWQ35CbdevWRe07G+qlAma2bNkS/JzqZyoIR4XV2CAa1V/PPvtsV7vxxhtdbcWKFYllAtFLhvodc+2bMQ477DBX++9//1ti225r6ruoWoUKFVxt69atOW1XeRJzHNqwq9jQwccff9zVHn30UVd7//33g+sC8P/q16/varVr104sz5o1qxS3aNdVkqGuXbt2Da5nzZo1rrZ48eKc/h4Q68svv4xqZ+871PWBup+w1xqqTUFBQdS1HXZMST4LGDJkiKvdddddpTqOKk2aNHG1lStXJpaPOOII1+byyy/P6e8RmF661HOSDh06uNqqVasSywsWLCj1e2nbF+vVqxf1fexzEvXMaPny5TltU3mnzlMxYcvqvNi5c2dXKywsDJ7LGjdu7GoNGjQIjtdqrImpqTFXPcNWpk2blvm1+E8IAAAAAAAAAACQCl5CAAAAAAAAAACAVPASAgAAAAAAAAAApIJMiB2ca1yx88vZeXeLVK5c2dXU+hctWhRso+YR27x5c3Cuc7Wuvn37utr48eN3eE40lNz8gWqOtpjPxcyxGjunqu1PsfPEqTniWrdu7Wpt27Z1tblz5wbXj9Kbs/Liiy92tf79+wf7iZqLfM6cOa5m561UWTdq22Oye9QYfNVVV7na9ddfn1j+8ccfXZvyLqb/5Dpv74wZM1ztoYcecrXbbrstsfzMM89k0nTBBRcE52pXY91ee+3lasuWLXO1p59+OrHMOTZ8Pkt7fuWY+WCvvvrqYCZYkeOPPz6TFnWeV7/NoEGDXM3OO0wmRPF9IPa4jBn/hg8f7mrXXXedq1WsWDGYHdemTRtXu/DCC13twQcfzJQENee+Op9OnDjR1d56660S2QakO4bYOabV/PlHHnmkq3388cfBa0B1DdGyZUtX69WrV2J5yZIlUXkoah5t5I/NWcg2R/qYMWMSy7Nnz45a/7fffutqH3zwwQ7nPxTp169fMBtj7dq1UffRKoMRJfOczY4NRVq1ahW8hlPrt88k1PlbjT0xGTXVq1d3bXr37h181qee2al7YpW5OG/evMQymRC5Ub+3ugbs1KlTYrlu3bqujXqWYJ/t7SXuF6tVq5bTs7dcszHVMaP+nrrH+PTTTzO/Fv8JAQAAAAAAAAAAUsFLCAAAAAAAAAAAkApeQgAAAAAAAAAAgFTwEgIAAAAAAAAAAKSCYOpAqGtMaHDz5s0Tyz/88ENUMPWKFSuCwYFVqlRxbVTwTY0aNYKBsWrbu3TpEgymRm59JzbkpmbNmonlSpUqRX3OhiSpgBm1XWpdts+qddntLPLdd98Fw5xs0GKRo446KhhMnWugcnkOzYz9zWxo26WXXhoVTD1lypTg31u4cKGrqfHIUoFwMVQfV6GsKrywRYsWwQDt8kSNWfYctG7dOtfmvPPOc7WlS5e62muvvZZYvueee1ybsWPHutr06dMTy7Vq1co5hPXmm28uNpiwyKZNm1zNBsepz6kx8ptvvnG1t99+O3gtUN6lGUStQiuHDh3qalWrVg2GBNepU8fV7r77ble74oorSuT7xX5OXXOieLkGxA8ZMsTVhg0bllg+5JBDXJvCwsJgCKrtg0WmTp3qagMHDkwtmPqpp55ytX322Sd4Pi1CMHXZEzOGqPvYCy64IOqawQajqmDfadOmudoll1wSDKFW90c2mFVdt2zcuNG1Qcmcb6+88srEcocOHVybJ554IngdFGvAgAGu9thjjyWW//3vf7s2EyZMCN4rXHfddVHbQAh1bmLuUdUxPmLECFf7+uuvE8tPP/101NgQEwasQoNjnr2pa0T1fex1o7peU9ulxsRVq1a5GnacCgePOTfuvffero0KO7f7eLs4FtS4op7d2uclud4XqHtP1cfU8fDJJ59kfi3+EwIAAAAAAAAAAKSClxAAAAAAAAAAACAVvIQAAAAAAAAAAACp4CUEAAAAAAAAAABIxR7lIUxahX+oz8UEo15zzTWuVlBQkFiuUKFC1LpV+K8NuVZBKSrk1YYUq2BNFebZsWNHV0PJ9LtYNrTI7stsgYkxQcVqO1XN9mEVwKSC6mwwtQpgUoFLv/3tb11t//33TyzPmDHDtSnPYkIze/To4WojR450tU6dOgXHFBXyZcOd1ZjSuXPnYCBxkVGjRiWW33jjjZxCzFq2bOlqq1evdrWZM2e6WqNGjcpNMLUdV1TYlQrFUkHUVvv27aPOlaofWCrEsmvXronlSZMmuTbHHHOMq3Xr1i04Ho0bNy4qWNiGwf7444+ZkqL2BZJq167taup8owJz69Wrl1hu165dVKi4DbB++eWXXRsVrq764iOPPJJYXrBggWszceJEV1uyZEmxoa/ZwrHVmG4D5+z1ZmlR1zilGUyezdFHHx3sS6eeempUaJ+9dlfnH3V9b8cVdZ+w7777ulrfvn1dzfaVMWPGuDYffvihq5144omJ5aZNm7o233//vaupdih7Yq6rNmzY4GrPPPNM1PqffPLJTGlS4ZpHHXVUYvnZZ58txS3adTVs2DB4faau/WICgmOpQGs7LqtrKhtCrcZXNR7G6t69ezCkuDxR53k79qixSN3rDhs2LPj31LOGk046ydXsfmnQoEHw2Ya6FlPXiF26dIkKKbbfW61b9cWVK1e6Gnbc7rvvntMzYDXexV6/2vvrAvPcLdt1u9pW+xxPjXfqWV9hYWHw3Bn7O5TE+MZ/QgAAAAAAAAAAgFTwEgIAAAAAAAAAAKSClxAAAAAAAAAAACAVvIQAAAAAAAAAAACp2OmDqW24iwrCUaEeKjzahjm3bdvWtRkyZIir2QBdFXCogutUiJvdVhU2ogLDbNiIChFWISh77723q9nfMB8BgbtCsFusmDA/tQ9y3S8qrMYGOtn+lK1mA6RUH1NBsyp8x4ZClqVgantcqv0fW8vVfvvtl1g+88wzXZsjjzzS1VRI/ddffx0M4apRo0YwiEiNRSrsVNUeffTRYD/ZuHGjq9k+Nnny5KhgahsapwJkVeBdWQ9xU1Rgrw08VSHUBx54YDC8+9VXX3VtLrroIlc7/vjjXe2mm24qdjlbuJwNQX3qqadcm+uvv97Vbr/9dle77bbbgr9DaVPBdWVdTLhw7HlKXR+dcsopwfBlRY1bNnhQnX9UKPTnn3+eWD7ggAOiQtwWLlzoatWqVUss169f37UZMGBAMLxYjZNqfFW/e5s2bRLLgwcPzuRDWbim7Ny5s6u98sorieVZs2a5NlWqVIk6x9r9rcIvx40b52q2ndq36ry4atWq4H3O6NGjXRt1LKxbty64bvv9VPB5Ee4ndk5qfFf3zar/lNR1thpb7XVwtnsTG9ROMHXJOO2001ztz3/+c3Bsbdeunau99tprJbZd06dPTyxPmDDBtVHn3Llz5wbHJ9XnVCjr6aefnliePXt2pixR9/4x1H2Hfc6lrs/UdZ0NwlXBuCqYWrHrt9c32Z5J2PDoVq1auTaqH6gx8V//+ldi+ZZbbsnk+7q7JJ877Cps348NXz7ooINcbcyYMcHrfbUP7DVTZXGvq/qd2lZ7rlT3sfY6Tn1OPStQz52rVq3qaieffHJi+Y477sjsKP4TAgAAAAAAAAAApIKXEAAAAAAAAAAAIBW8hAAAAAAAAAAAAKnYbXvk5GG5ziW3M7Hz/V599dVRc0/Wq1cv+Fupedxq1aoVnHPTzgecbf5ZOxermp9Pzeml5rc94YQTip0zsTTnnNtZ+p3aTlVT872NHDkysXzsscdGfS7m78XMM68+u2zZsuDfU59TfVPNZ6fmkW3cuHFi+dxzz3Vtvv3228yu1ufUPOBqrvx99tmn2FyHbHMyq+PeznVu151tDLHzkVesWDETI2aOQTV3p5ob1M6jqOaAV7+D6od2zkQ7V2i+xzp7/P6a3BG7Dy688MKoc9Ill1ySWL788stdm7/97W+u9ve//z14blGZRDHU3NTz5893tSZNmmTyTY3BPXr0CM65ro7vXWG86927d1QtZmyxeSVFVq5c6Wo2X0hlZh1++OHBcURlpqi+uMcePm7N5ufYjJZs87Pa8U3N8zpz5kxXa9myZfD3svNoF7n44osz+ehzNrNHZau1aNEieP1dpG7dusH5yFUfsOtS18fq91ffx+ZJqO/TrVs3V3v//feL3abYHDF13ai2U12L2XmD1dze6t5EnYsOOeSQYvN9sn2uPN9PILt33nkneO9QZMmSJYnlww47LC/9blfrcy+88IKrvfjii4nlZ555xrU56aSTXM2OKypnRo23Kptp3333LfZas8ihhx7qav379y/2u2Q7D6jrDHv9vHz5ctdGPU/ZGfud3XfNmjVzbVR+ld0ue5xmY88j6hpR3Quq+wJ7/zto0CDXRmVVxOTkqBwpdT9a2sr6OTY2Y86uP/YZV0zOyIknnuhqQ4cODfZ99fdU3oPtn5XE9b7KMFbf0d7Pq+cb6rmhvQ+JvSZU9zlfffVV8NllqN/xnxAAAAAAAAAAACAVvIQAAAAAAAAAAACp4CUEAAAAAAAAAABIBS8hAAAAAAAAAABAKnx6XhmmwjliAntV2OZVV13lah06dEgsf/DBB66NCrizVLiSCmObPXt2MAxWBRzGBMyogGAVNqK0adMmL0FKOzMVvKuC+xo0aOBqffv2DfYVFeBqg2hiA3pUgI3dVhVCo2p2/aqN2q6NGzcGjxsVrFlW9q/6TrVr13a1gQMHupoNwercubNro/rA5MmTg8GmKrBSBajZIGr1W6sQcLuPVLin6qsxQa1qzFKh2rbvqHHtp59+igp8Uu3Ksthwsa5duwbPLVdeeaVr88UXX7javHnzEssjR450bapXr+5q55xzjqudccYZieU777wz6twcM7YWFha6Wsz6VQDyEUcc4WqDBw9OLLdv3z4qwFCF5dnj9NZbb83sbNq2betqxx13XDCgrVOnTlH7zoY6rl692rVZtmyZq6kQXdtOBSbaYEs13qmxxo6lamxT11UqlO7LL78Mhmqr4MM+ffpEhbV+8803wXG5NDz22GPBkOapU6e6Nq1atYq63rbjuhrn1T6y10Y24Dpb2Kg6D9rtWrp0qWvTpEmTYIDrggULosYU1Z8s9TsUFBTkdK+wfv36qGMoZrsApXfv3lHnne+++87VbOCmCs7FjlPPXE4//fRgMPXzzz8fvL6316hFunfvHrwmLTJ27Njgdd3rr7+eCTn44IOjxk11DzhhwoTguSmf7D2QehYQy54/Fy1aFDX216xZM6e/p843Njxa9Yuzzz7b1c4999zgtcCf/vSnnLZTfefzzjsvGLiuroHVdqmgdhu6nM9ndiro2PY7NYbEPMtVYvuwvTe79957o66Z1XODmG2PDZi2Yq/J7T2w+t1VILody9T9kromVMdfSTyj4z8hAAAAAAAAAABAKngJAQAAAAAAAAAAUsFLCAAAAAAAAAAAkApeQgAAAAAAAAAAgFT8qlQ6G4ShgjGUmAASta6Yz5166qnBEJoiEydOdLUbb7wxGDioQq5tMIoK6VRBHyqEybZTwTQ2jEeFAqlAEhWkqb6jDWZ69dVXXRsUHwyUjQpJskFGKqA35nhQx4cKslX90wYhq1AvFVZoA5tVKJPaLhXkbYODVChxaVDh4R999FFiec6cOa6NCuVu3ry5qy1cuDCx/MknnwTDXFWAkAqAVvtIhWva/RQb8Gr7kwoKVceCCtG2fVoFTKl+v2XLlmKXs/VfRY1/+RJzjKtgK3V8vfHGG652zz33JJb/8Y9/RP1ul1xySWL5uuuuc23OP/98V3vzzTdd7Y477ih23bHB1Ir6PpdddpmrHXTQQYnlnj17RoWK2X6txlZ1/NkgdRWyrEIbb7jhhkxZofa5+l4zZ84Mtvv4449dG3UM25oaX7t06RIVDm5D3Bo1ahQMtlR9pUWLFq6NChRU53AbFmjPA9nOn/Xr108sH3PMMVHHrQpptOeMXMMAfy31+9vAWfVbq99VhYzbcD91vaHOzXb9KoRaBQeqYNxBgwYVG0yejd0GFairxh51jo05N9tj49dQ4YX56mPY+akAe9XP1bWjPeYJps4Uey2pjlN1D/af//wneA5s0qSJa3PggQe62ssvvxwcPxYsWJCJ0bdv32A477Bhw4LXrrfddptr88UXX7har169XM1+b3X+KC0XX3yxqw0dOjSxPGXKlKhzmTrmbMCtuo/99ttvXc32syFDhgSvu7KFiq9atarYa6UiK1euDJ77a9eu7dr89a9/dTV17WqvB7755hvXplu3bq7WsWPH4HM9dR+ijlN7PTVgwIBMvqhrk9jnYzHXWvY36d27t2tz6KGHBtf14osvRt0vqnsT2/dVv4t5BrGbuOePrdnxWwWWq21Q194x/W7x4sWuZu/JWrdundlR/CcEAAAAAAAAAABIBS8hAAAAAAAAAABAKngJAQAAAAAAAAAA8psJETMXtZoLLFex6+rUqVNi+bDDDnNtnnzySVebP39+cH5wNWesmj/Vzoul5kpWcyuqebfs3IpqvmG1fjvfmZqbS817p6h53lH8vlNzkqp5Me28lUWWLl0azB1R+9zOs6fmzFb5DzH9R81tHjNXnZrTM2a+VjV/nZpPsjTYuZzVfHs1atQIzhOYbT5TO+93y5Yto8Zbu79VG7UNar/Zdam++sMPPwQ/p+YPjc3EsceQmutSrcseH6ovqX6ofod89TFFnQ9sTX0Hdaw+8cQTwTlI1dyQ/fv3D+bY3Hnnna6N2i41R+VRRx2VWB4xYoRro+b4tJksKqdIzYOq5rK1+UnHHnusa6OymF566aXgsRbL/l6/Zl1pGDlyZHAMnzBhQlSejr32Ud+1YcOGweM8Zn7YbGOzHd9ij3s7D7H6e+qaUJ3DbSaAynZQx6Qd51UugrpO3HfffV3N/oZqHuJ89K8ijz76aGK5Xbt2UeuqVq1asI0an9R+s9dG6j7E3nNkm/PZ9hU1P7gaZ2xNbUNs/pe9plLn4Zh1qTbqWFB989JLLw3Ou4xMTn24JO+506TuTdTx17lz52AumbquUFk6tp1qU57FZLWofaSeZdgcJnX9bceBIldccUXw2lJd66lrRHue/Oqrr1ybhx56yNW6d++eyYXK5LPnInutWZrU9bC9V7D3BNnEjDPq2YbKPbX7SWU6qc8NHDgw+MxOZSmqjAZ7PauOhcGDB7va0UcfHTxG1H25yhWIySlTv7s6D9jrzQ4dOmTKEnvN9Pvf/961UWO9zSpVGZeTJk1ybR588MHgc031DPi1115ztSOOOCLYf9T1t804U9djW8X4qvqPqtnnM2pd6lmuvf9SfV9dx6lnPY0bNw7mj4bwnxAAAAAAAAAAACAVvIQAAAAAAAAAAACp4CUEAAAAAAAAAABIBS8hAAAAAAAAAABAfoOpY0KMVBDekCFDXG3//fcPrksFtqkAThtMU69ePddGhdWobbBBIioASwWl2t9GBSiqECMV1mUDZlSwiAoIsQGc6rdS4ZKxYcYI/5bWWWed5Wpr1qxxNRusq/prTHigCvZRwUYq5Mb2n9iAY/t9VFhh/fr1cwrhVX24NKgwsZjfWgXfqf1m96/6LVSwqQ17U+FBig2NU31O9QkVrGTHRLUNqqbC0G1IpgoRnj59enD8U7+fClydPHmyq02bNi1TVtjQ72y1GCr80/afZ5991rU577zzgkG/akyxoc3ZAmNtmPFnn33m2owdO9bV7HldjQ233367q6mgw5ix2wZoq99BhZGpMVL1T7tf1XmhtNjA5NjfW4WY16xZMzguqrEg5ppGHQsqjG3VqlXB/Rkb/mbDAlXwtg29zhbeac+psWOnDTVUfUUFbatAxtmzZyeWx48f79qcc845mbTNmjXL1Q466KDE8pgxY1ybww8/PHgPoKg+Z8+BRVq3bh0MlFT3Joo97tU4ULt27WDYn7qGUH1VsceMuq5TNfs31Zipvo+69+nTp09O276rBkWr729/y9jg8Zi/V5KB1mrbY7ZLjdPKqaeeGly3OibVdtl7fBVyiv83dOhQV1uwYIGrqfDRE088MRh4fPDBBwdDoXv06OHaXHjhha723nvvudpjjz2WWL744oujQq5jzgtqjFTjX/v27RPLEydOzOSL2mb7HGr16tVR61LXJXZcUdc86li1n1PPO2LuF9W9ujpPqfHPjhfqvGWDf2Pvx9Q2xDw/jT0vxqxr8eLFmXxRzw/vueee4D5Rv+24ceNc7f777w/24QMPPNDVDj300OD4oO7p1P6094JqzFi5cmXwGXkNs55s5yl1HrT3ZOo5j+rDMc/V1He2zw/Ubz9z5szMjto1rgYBAAAAAAAAAECZw0sIAAAAAAAAAACQCl5CAAAAAAAAAACAVPASAgAAAAAAAAAA5DeYWjnllFMSy126dIkKHHzllVdczQaVNGvWLCqs9e233w6G8S1btszVjjvuOFez4SIqYEUFE9pAGRXgoUJnVMCdDSBRISLNmzcPhrqoYB8VaKOCqWOD98oLte/sb6mCznv27BkVFGNDjtV+ignGUp9T+1KFTNn1q+AgFUhmg67UMaoC3lX4TsWKFTNlwbvvvutq119/fTCUVY11MQHcKpBZhXzZ0Mw6depEhQGrkGYbZGoDg7PtI7utKnzpww8/zCkMWIU7qbCqmFBFtS4VPmYDeBs2bJjJF3XsDBw4MPjd1bE6Y8aMYJifChFWgcwPP/xwYvmaa66JCjFXbP857LDDooKFn3/++cTyueeeW2Jhm8qRRx4Z7MOqT6t+p9h+HRsynwZ7/lEhgOrYUWOb6lN2XFf93AZAq7+pggljA6bt762uL9U+sGPnF1984dqooGgV6GnXr8Z9de1ov7f6jdVYra5f7e/QtGnTTD7EhOWOHDnStVG1IUOGuNoZZ5yRWO7bt69ro4L8bIh6SVLjhTo327BNNa6pdal+b89vNvT611Dhl6ofrl27Njhu7IzUfrH7IGYsig0bzfU4ij0v2v2Sa8Cq0rlzZ1e76KKLXM3eR33++eeujbrmnD17dvA6dMqUKZldke1jsftowIABwXsA1X9vvvnm4DOJ6dOnuzadOnVytUmTJgX3rQqLVc83evXqFfw+MaHTMfcq2X4bex2c6/FSEl5++WVXO/3004PPklRYrvpN7HWJ2ifquYUdj9Q5V13rqfOG3Qexn7NjsHrOpvbd1q1bg+1U0HbMs43YcXrp0qWuZr+32oelxfYxtY/VNbN6dmGfMRc555xzgvtEHef2b6r9q3439UzAPgdW+1yt3z53WSyuodR9gfqO9vreXmcVmTdvnqvFjG9qX6j7RHsvd8wxx2R2FP8JAQAAAAAAAAAAUsFLCAAAAAAAAAAAkApeQgAAAAAAAAAAgFTwEgIAAAAAAAAAAOQ3mFoFbxx//PHB4AoVyDJo0CBX++ijj4IB0yqw0ga4qkBXFZSiAjhtsI7adhUqZsN3VCCJ+pwKe4wJz1MhJTZsRO0LFdCjwhhtu5IMsyvrVFC3+r2t6667ztVig5pscLMKaooJD1XUtqt+bQOs+/Tp49q89dZbrnbQQQcFQ5NiA/XscZPPUC/r9ddfTyyPHz/etWnRooWr9e7d29VsoLQKY3vzzTddzfYLFdhmgyizBWbb8CMVsqYCUO04psKxVaivDTBXIaxqjFT9xAYyqeNAbZdqZ89r9jxUmlRI80033RQcG9S5WQVz2dDQmP2rjsOJEydG7V8VtGaDfZ988knX5v7773e1qVOnZkpq7LbjnwqlU0Hbtv+o311tg/odVPBXvqjfdtmyZcH+pALU1PWE/Z1UX1E1+xupdatzrKrZfh0b8G77ijp3qn2uxmH7WRUcrQK67efUNaEK2lbXl3bMVcF4paEkQ+Rfe+21qFrM9bC91o0NmlfnT3tNtXz58qh1Yeeg9nmu17D2+FXBnSp4siSPo5jASnUfogKmu3fvHhwj1b3Co48+mlieNm2aa6Oul9U5vH79+pnyIKaPHXDAAcFrowULFkRdM9t9W2T48OGJ5SeeeCJ47VdkxIgRwX377rvvRj3TUUHUMfffuVLrKkvXdWofqFrMd2jatGmwb6jrElWz42bMM5Fsx7i9NrLn3Gz3NLadumZU14OqFnPMqGsxW1PnExWUrJ5x2oDxr776KpMv6pnHli1bgr+jbRN7nlK/kRoTbYiyupeOvb+2/U6dm9V4avtZNXGsxX4f21/Uva4N0FafU+tW/VW1s9vfv3//zI7iPyEAAAAAAAAAAEAqeAkBAAAAAAAAAABSwUsIAAAAAAAAAACQ30yIk046KThvsppTUs39peZZtXP8qfla1dxu9m+quazUXGtqDjg7F5eaA0vNbWnX37Bhw6g57tS8bXb9ao479fvZ7622Xc0fGjPPnvo+pUX1n1znQY353dQ818pVV10VnCv166+/juo/dj7s2Hkl7bar40+tS80DPXTo0GLn6iwyduzY4LrUutV3Vttqj/mylAkRs/3z5s2Lqtm5CZs0aeLaqHHM5hyo8VDNAajWZecPVOtS83nGzNuosnvsHPPq2I7JI1C/g/p+s2bNcrUlS5a4Wr7mRFeee+65qFpoPtBs41GbNm2C87yq8cL2VzWHq9q/kydPdrVPPvlkh+ehVtQ+V/0nV6NHjw4eyyq3Kub6QF0P2Ln6883Ozax+b/Vd1fhjqe+qavZ8rcYCNf+uqtlzS+zcr/Zz6tpD9btvv/02OOaq40ity465sfli6tpRzbldXqmxZ9GiRXnZFux8YuZp7ty5s2vTtWtXVxs8eHDwvufYY4+N2i772dj7JXvuv/nmm6Nyq9R50GaaqQw1dZ1of1M1RqprUDXm9+jRI7E8Y8aMzK7I5g+pPDR1j2EzM9T1sZrXXO3vyy67LLF81llnuTaXX355cBvstWa2Mfnxxx/P5FtslsHORn0HdT8FKDH3kOo5mzqe1PNJe11rsw6zZczZ6/vYZ9MrVqwIHiPqeXLMb1NZ3HOo87Wq2d9LZYXEZDuobVDnWHXfYfdj7O/wv/hPCAAAAAAAAAAAkApeQgAAAAAAAAAAgFTwEgIAAAAAAAAAAKSClxAAAAAAAAAAACC/wdQqCGjmzJmJ5ZNPPtm16dWrV1QAiQ0EUaGoNjBZBYGpwBMVQBITxKpCSxcuXOhqb7/9dmJ50qRJrs2cOXNcbeTIka527733BkNXVKCeranvrGoqdKVu3bqJ5WbNmmXKEvs9VIi5Co1T/c7W1G905plnutoBBxwQDCBWgS8qMNb2axWyFhMurL6zCqI86qijgn3xkUcecW323XffTIg6rtT+UXINHN/ZrF69utjlbKZOnRpsM2XKlJy3CzsnFRSo7Erhcr8mhFqFnVnjxo2LqpUX6vdWtfnz55fSFgFA/qhr+RtuuCF4badC6995553E8jnnnJPzdsVcR1900UWuNnz48OD974gRI1zt448/drWWLVsmln/44YdUQ3xVkKYNMN1V7y9suHPr1q1dm1deeSUYFrtp06aov6f679133x0MeI0Jk1Z9Tt2TlyT7DCn2eYK6joy91wV2VSqc2AYyq2Najc/qeLLt1H2IOh+sWbOm2Odnsc+mi1SqVCn4zE49w7bP8bZF3seqZ9+5PN9UNXUetmNiNvZ3aNSoUdTnEn9rhz8BAAAAAAAAAAAQgZcQAAAAAAAAAAAgFbyEAAAAAAAAAAAAqeAlBAAAAAAAAAAAyG8wtfLZZ58Vu7wjgV5NmzZNLFetWjUq6NcGaKigj7Vr17rakiVLXE2FQKfp5ZdfDgZfT5s2zbVZv369q9kAtNgwJxV4rMJM8kUFpNgQ7thwl+bNm7tau3btEstHHHGEa1O7dm1XW758eWK5Zs2aro0Kq1E1G76jAnpUzR4jX3/9tWszaNAgVxszZoyr/eUvf8mE1KhRIxjYpfqT2ocxAV4qDAwAAADIFxt8rK7J1X1Bz549Xa1evXrBMMzYMM/evXsnlq+++mrXpm7duq521113JZafeeaZTK7atGmTWH7zzTczaVL3VfZeZFcNpp4+fXowxFTd0xcWFiaWu3Xr5tpMmjQpp21S61IBqDbUvEOHDlHrV/eUud4v5vo5dYyWpWcnQD6cf/75wWdO6jhXz4XV8WTPg+o4VOcD+7kKFSpEjSsqwNqOGbFBzvZv7hX5nVW7b775JvjsbfPmzcEw6R9//NG1UecQNU7abVX7IoT/hAAAAAAAAAAAAKngJQQAAAAAAAAAAEgFLyEAAAAAAAAAAEDZy4Qoybk058yZkylv7Jxe2Wq5iJ3/sqzPYWjzH5QTTjjB1Xr16uVqderUCa5rzZo1UVkhjRo1SixXqVIlKvdA1excbmruNfU5mwFht6nI66+/7mq33HJLJhdqzrnFixeXWP+0+3pXncMVAAAApefkk092tVGjRgXvwVSG4Lx581xt4MCBwRzDjRs3Bu+J1fz577//vqu1aNHC1Ro3bhzMdjjyyCMzuYjNpbB5A507d3Zt1H2OnYta3XOo+bG3bNkSnH9brWtno/pTw4YNg89SmjVr5moHHHBAYrlPnz6uTatWrVxNHR92LvBFixa5NqNHj3a1a6+9NrjtZTUvUD0r+OGHH/KyLUBZsXLlSlf7wx/+EBzDR4wYEXWesuc8dT5VeQ9W9erVo56z5XpMq9wlm/H7wgsvuDZvvPFG1LWGHb+nTp3q2ixYsMDVbH5F27ZtozIh1JhuzysqwziE/4QAAAAAAAAAAACp4CUEAAAAAAAAAABIBS8hAAAAAAAAAABAKngJAQAAAAAAAAAAUrHb9sj0VxVIhfKrtEKDa9SoEQxWrlatWtS6Nm/eHAzUUv1chYEVFBQUu5wt5EYF5tiQLdVGhWNbe++9t6upsDHFhtWo4K/evXu72h133JFYXr9+fXDd2fZF/fr1E8u/+93vUgtuLw5jHfIx1tHv8L/od9hV+x19DmVlrLP3GK1bt3ZtmjRp4mo1a9Z0NXsfoAKT1f2EvXZX9xNq29977z1XGzduXCYX9n7l559/jtoGte969OgRDNDetGmTq23bti3YRlH3HTY4WIV0qu9Y0v74xz+6WqNGjYIhx2vXrnU11S+qVKkSDDVv2rRp8L7MBlwXmTJlSlTwrF3X0Ucf7drMnTvX1e67775MWWOfCRT56aefXO20005ztQceeCCxXLVqVdeG6zrkw67a79TY1qpVK1dr3759YrlOnTpRx74Kpl61alViec6cOa7Np59+milNDz/8sKstXLgw2A/Us7gNGza42urVq4PPJdXvEHp2yX9CAAAAAAAAAACAVPASAgAAAAAAAAAApIKXEAAAAAAAAAAAIBW8hAAAAAAAAAAAAKkgmBplOuTmmmuucbV+/follpcuXera7LHHHlGBcPZ7qCC5SpUqBdevjg8VIqbYcLTYQLj99tsvsdy2bVvXRn2fXEPpDj/8cFe74YYbggFral0q6MuG86lAN7WvSxpjHcpDoBfKNvod8oFgapQ2xjqUp7HOBhY3a9YsGJieLUxV3euGgqNV7Zdffsl5G+z940MPPeTaFBYWZsqimN9BUff3xx57bGL52WefdW0Y65AP9DuUxX7Hf0IAAAAAAAAAAIBU8BICAAAAAAAAAACkgpcQAAAAAAAAAAAgFbyEAAAAAAAAAAAAqQgnGgF59Pzzz7tax44dE8stW7aMWlfdunVdbdu2bcEg5/Xr17uabafClxUVemXXpb6PDTIr0qtXr2LXky20zH7n2GBqtX7bToUSVahQwdX23HNPV4vdjwAAAACwM7H3lLNmzcrbtpR3sUHUMffDKogaAKDxnxAAAAAAAAAAACAVvIQAAAAAAAAAAACp4CUEAAAAAAAAAABIxW7bt2/fHtVQzPWO8iuy2/xqMf2udu3arta8efOozIE2bdoklhs2bOjaVK9e3dUqV66cWC4oKHBtKlWqFJXHYHMVpk+f7tpcccUVmVz85je/iZoD02ZHqO2sU6eOq7366qs7nJ+Rbb+uXLkysXz22Wfnpd8x1qGsjnUoP+h3yAfOsShtjHXIB8Y6lDbGOuQD/Q5lsd/xnxAAAAAAAAAAACAVvIQAAAAAAAAAAACp4CUEAAAAAAAAAABIBS8hAAAAAAAAAABAfoOpAQAAAAAAAAAAdgT/CQEAAAAAAAAAAFLBSwgAAAAAAAAAAJAKXkIAAAAAAAAAAIBU8BICAAAAAAAAAACkgpcQAAAAAAAAAAAgFbyEAAAAAAAAAAAAqeAlBAAAAAAAAAAASAUvIQAAAAAAAAAAQCp4CQEAAAAAAAAAADJp+D/jA4fdIYQs1AAAAABJRU5ErkJggg=="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 31
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Hyperparameters",
+   "id": "c4c6d7c1452702d1"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-01T21:53:56.218198Z",
+     "start_time": "2025-03-01T21:53:56.192312Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "BATCH_SIZE = 256\n",
+    "SEED = 42\n",
+    "EPOCHS = 100\n",
+    "Z_DIM = 64\n",
+    "\n",
+    "key = jax.random.PRNGKey(SEED)\n"
+   ],
+   "id": "aaa370e050e81383",
+   "outputs": [],
+   "execution_count": 40
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Architecture of the Generator",
+   "id": "e8f374443f907b4a"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-01T21:53:12.718594Z",
+     "start_time": "2025-03-01T21:53:12.692915Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "class Generator(nn.Module):\n",
+    "    features: int = 64\n",
+    "\n",
+    "    @nn.compact\n",
+    "    def __call__(self, x, train: bool = True):\n",
+    "        x = x.reshape((BATCH_SIZE, 1, 1, Z_DIM))\n",
+    "        x = nn.ConvTranspose(self.features*4, kernel_size=(3, 3), strides=(2, 2), padding='VALID',\n",
+    "                             kernel_init=normal_init(0.02), dtype=jnp.float32)(x)\n",
+    "        x = nn.BatchNorm(use_running_average=not train, dtype=jnp.float32, axis=-1,scale_init=normal_init(0.02))(x)\n",
+    "        x = nn.relu(x)\n",
+    "        x = nn.ConvTranspose(self.features*4, kernel_size=(4, 4), strides=(1, 1), padding='VALID',\n",
+    "                             kernel_init=normal_init(0.02), dtype=jnp.float32)(x)\n",
+    "        x = nn.BatchNorm(use_running_average=not train, dtype=jnp.float32, axis=-1,scale_init=normal_init(0.02))(x)\n",
+    "        x = nn.relu(x)\n",
+    "        x = nn.ConvTranspose(self.features*2, kernel_size=(3, 3), strides=(2, 2), padding='VALID',\n",
+    "                             kernel_init=normal_init(0.02), dtype=jnp.float32)(x)\n",
+    "        x = nn.BatchNorm(use_running_average=not train, dtype=jnp.float32, axis=-1,scale_init=normal_init(0.02))(x)\n",
+    "        x = nn.relu(x)\n",
+    "        x = nn.ConvTranspose(1, kernel_size=(4, 4), strides=(2, 2), padding='VALID',\n",
+    "                             kernel_init=normal_init(0.02), dtype=jnp.float32)(x)\n",
+    "        x = jnp.tanh(x)\n",
+    "        return x"
+   ],
+   "id": "40529a6c88ac7cc",
+   "outputs": [],
+   "execution_count": 39
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-01T21:54:13.449907Z",
+     "start_time": "2025-03-01T21:54:11.200175Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "generator = Generator()\n",
+    "params_generator = generator.init(key, jnp.ones((BATCH_SIZE, Z_DIM), jnp.float32), train=False)"
+   ],
+   "id": "c46461f414506279",
+   "outputs": [],
+   "execution_count": 41
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Architecture of the Discriminator",
+   "id": "40b40969c1e3d5ad"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-01T21:56:57.606127Z",
+     "start_time": "2025-03-01T21:56:57.589307Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "class Discriminator(nn.Module):\n",
+    "    features: int = 64\n",
+    "\n",
+    "    @nn.compact\n",
+    "    def __call__(self, x, train: bool = True):\n",
+    "        x = nn.Conv(self.features, kernel_size=(4, 4), strides=(2, 2), padding='VALID',\n",
+    "                    kernel_init=normal_init(0.02), dtype=jnp.float32)(x)\n",
+    "        x = nn.BatchNorm(use_running_average=not train, dtype=jnp.float32, axis=-1,scale_init=normal_init(0.02))(x)\n",
+    "        x = nn.leaky_relu(x, negative_slope=0.2)\n",
+    "        x = nn.Conv(self.features*2, kernel_size=(4, 4), strides=(2, 2), padding='VALID',\n",
+    "                    kernel_init=normal_init(0.02), dtype=jnp.float32)(x)\n",
+    "        x = nn.BatchNorm(use_running_average=not train, dtype=jnp.float32, axis=-1,scale_init=normal_init(0.02))(x)\n",
+    "        x = nn.leaky_relu(x, negative_slope=0.2)\n",
+    "        x = nn.Conv(1, kernel_size=(4, 4), strides=(2, 2), padding='VALID',\n",
+    "                    kernel_init=normal_init(0.02), dtype=jnp.float32)(x)\n",
+    "        x = x.reshape((BATCH_SIZE, -1))\n",
+    "        return x"
+   ],
+   "id": "91a5c2c77297674e",
+   "outputs": [],
+   "execution_count": 43
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-01T21:57:10.941133Z",
+     "start_time": "2025-03-01T21:57:09.902739Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "discriminator = Discriminator()\n",
+    "params_discriminator = discriminator.init(key, jnp.ones((BATCH_SIZE, 28, 28, 1), jnp.float32), train=False)"
+   ],
+   "id": "15840b9539801b7d",
+   "outputs": [],
+   "execution_count": 44
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-01T22:05:06.358198Z",
+     "start_time": "2025-03-01T22:05:06.346777Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "def generator_step(generator_state,\n",
+    "                   discriminator_state,\n",
+    "                   key):\n",
+    "    input_noise = jax.random.normal(key, (BATCH_SIZE, Z_DIM))\n",
+    "\n",
+    "    def loss_fn(params):\n",
+    "        generated_data, mutables = generator_state.apply_fn(\n",
+    "                {'params': params, 'batch_stats': generator_state.batch_stats},\n",
+    "                input_noise, mutable=['batch_stats'])\n",
+    "        logits_fake = discriminator_state.apply_fn({'params': discriminator_state.params,\n",
+    "                                                    'batch_stats': discriminator_state.batch_stats},\n",
+    "                                                   generated_data, mutable=['batch_stats'])\n",
+    "        loss = -jnp.mean(jnp.log(nn.sigmoid(logits)))\n",
+    "        return loss, mutables\n",
+    "\n",
+    "    grad_fn = jax.value_and_grad(loss_fn, has_aux=True)\n",
+    "    (loss, mutables), grad = grad_fn(generator_state.params)\n",
+    "    # Average across the devices.\n",
+    "    grads = jax.lax.pmean(grads, axis_name='num_devices')\n",
+    "    loss = jax.lax.pmean(loss, axis_name='num_devices')\n",
+    "\n",
+    "    # Update the Generator through gradient descent.\n",
+    "    new_generator_state = generator_state.apply_gradients(\n",
+    "            grads=grads, batch_stats=mutables['batch_stats'])\n",
+    "\n",
+    "    return new_generator_state, loss"
+   ],
+   "id": "a4a9f642bbf2533",
+   "outputs": [],
+   "execution_count": 46
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "",
+   "id": "48d28b8f2ba4d7a6"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This commit introduces a new Jupyter notebook that implements a Generative Adversarial Network (GAN) using the JAX library. The key changes are:

- Imports necessary JAX, Flax, and Optax libraries for building the GAN model.
- Loads the Fashion MNIST dataset and selects a subset of the training images with labels 5, 7, and 9.
- Displays the first 10 selected training images.

The purpose of these changes is to provide a starting point for experimenting with GAN models using the JAX framework, which offers efficient and GPU-accelerated numerical computations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive notebook that demonstrates a Generative Adversarial Network (GAN) implementation using the JAX library. Users can explore environment setup, data loading and preprocessing of a popular fashion image dataset, image visualization, and an end-to-end training workflow with model components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->